### PR TITLE
Support spaces around tokens in the require statement for :require_rewrite

### DIFF
--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -44,7 +44,7 @@ module Rake::Pipeline::Web::Filters
     def generate_output(inputs, output)
       inputs.each do |input|
         code = input.read
-        code.gsub!(%r{^\s*require\(}, 'minispade.require(') if @rewrite_requires
+        code.gsub!(%r{^\s*require\s*\(\s*}, 'minispade.require(') if @rewrite_requires
         code = %["use strict";\n] + code if @use_strict
 
         module_id = @module_id_generator.call(input)

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -55,4 +55,10 @@ describe "MinispadeFilter" do
     output_file.body.should ==
       "minispade.register('/path/to/input/foo.js', function() {\nminispade.require('octopus');\n});\n"
   end
+
+  it "rewrites requires if asked even spaces wrap tokens in the require statement" do
+    filter = make_filter(input_file("require    ( 'octopus');"), :rewrite_requires => true)
+    output_file.body.should ==
+      "minispade.register('/path/to/input/foo.js', function() {\nminispade.require('octopus');\n});\n"
+  end
 end


### PR DESCRIPTION
Some users have syntactically valid spaces (please don't ask why, I don't know) around the require statement. Like,

``` javascript
require    ( 'octopus')
```

 The require_rewrite was skipping them. This trivial change basically tests for spaces around the open parentheses.
