### PR TITLE
Resolve relative references in require

### DIFF
--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -50,6 +50,12 @@ describe "MinispadeFilter" do
       "minispade.register('octopus', function() {\nvar foo = 'bar';\n});\n"
   end
 
+  it "resolves relative references if asked" do
+    filter = make_filter(input_file("require('./squid');\nrequire('eel/electric');\nrequire('../whales/humpback')"), :resolve_relative_references => true)
+    output_file.body.should ==
+      "minispade.register('/path/to/input/foo.js', function() {\nrequire('/path/to/input/squid');\nrequire('eel/electric');\nrequire('/path/to/input/../whales/humpback')\n});\n"
+  end
+
   it "rewrites requires if asked" do
     filter = make_filter(input_file("require('octopus');"), :rewrite_requires => true)
     output_file.body.should ==


### PR DESCRIPTION
Allows relative reference of modules. In ember-views/lib/system/application.js, instead of,

``` javascript
require("ember-views/system/event_dispatcher");
require("ember-views/views/something/something_else");
```

one could do,

``` javascript
require("./event_dispatcher");
require("../views/something/something_else");
```

This would help keep the code agnostic of overall package structure and naming.

Not sure if you are accepting pull requests on this repo. But, I thought I could propose things that I found useful.
