### PR TITLE
Remove newlines from handlebars/minispade filter

### DIFF
--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -48,7 +48,7 @@ module Rake::Pipeline::Web::Filters
         source = input.read.to_json
 
         # Write out a JS file, saved to target, wrapped in compiler
-        output.write "\n#{options[:target]}['#{name}']=#{options[:wrapper_proc].call(source)}\n"
+        output.write "#{options[:target]}['#{name}']=#{options[:wrapper_proc].call(source)}"
       end
     end
 

--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -52,9 +52,9 @@ module Rake::Pipeline::Web::Filters
         if @string_module
           contents = %{#{code}\n//@ sourceURL=#{module_id}}.to_json
         else
-          contents = "function() {\n#{code}\n}"
+          contents = "function() {#{code}}"
         end
-        ret = "minispade.register('#{module_id}', #{contents});\n"
+        ret = "minispade.register('#{module_id}', #{contents});"
         output.write ret
       end
     end

--- a/spec/handlebars_filter_spec.rb
+++ b/spec/handlebars_filter_spec.rb
@@ -1,14 +1,13 @@
 describe "HandlebarsFilter" do
   HandlebarsFilter = Rake::Pipeline::Web::Filters::HandlebarsFilter
 
-  let(:handlebars_input) { <<-INPUT }
-<h1 class="title">{{title}}</h1>
-INPUT
+  let(:handlebars_input) {
+    '<h1 class="title">{{title}}</h1>'
+  }
 
-  let(:expected_output) { <<-OUTPUT }
-
-Ember.TEMPLATES['test']=Ember.Handlebars.compile("<h1 class=\\\"title\\\">{{title}}</h1>\\n");
-OUTPUT
+  let(:expected_output) {
+    "Ember.TEMPLATES['test']=Ember.Handlebars.compile(\"<h1 class=\\\"title\\\">{{title}}</h1>\");"
+  }
 
   def input_file(name, content)
     MemoryFileWrapper.new("/path/to/input", name, "UTF-8", content)

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -29,36 +29,36 @@ describe "MinispadeFilter" do
     filter.output_files.should == output_files
     output_file.encoding.should == "UTF-8"
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {\nvar foo = 'bar';\n});\n"
+      "minispade.register('/path/to/input/foo.js', function() {var foo = 'bar';});"
   end
 
   it "uses strict if asked" do
     filter = make_filter(input_file, :use_strict => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {\n\"use strict\";\nvar foo = 'bar';\n});\n"
+      "minispade.register('/path/to/input/foo.js', function() {\"use strict\";\nvar foo = 'bar';});"
   end
 
   it "compiles a string if asked" do
     filter = make_filter(input_file, :string => true)
     output_file.body.should ==
-      %{minispade.register('/path/to/input/foo.js', "var foo = 'bar';\\n//@ sourceURL=/path/to/input/foo.js");\n}
+      %{minispade.register('/path/to/input/foo.js', "var foo = 'bar';\\n//@ sourceURL=/path/to/input/foo.js");}
   end
 
   it "takes a proc to name the module" do
     filter = make_filter(input_file, :module_id_generator => proc { |input| "octopus" })
     output_file.body.should ==
-      "minispade.register('octopus', function() {\nvar foo = 'bar';\n});\n"
+      "minispade.register('octopus', function() {var foo = 'bar';});"
   end
 
   it "rewrites requires if asked" do
     filter = make_filter(input_file("require('octopus');"), :rewrite_requires => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {\nminispade.require('octopus');\n});\n"
+      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');});"
   end
 
   it "rewrites requires if asked even spaces wrap tokens in the require statement" do
     filter = make_filter(input_file("require    ( 'octopus');"), :rewrite_requires => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {\nminispade.require('octopus');\n});\n"
+      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');});"
   end
 end


### PR DESCRIPTION
The reported line-number for errors is incorrect in the Chrome/Webkit developer console with them included.
