### PR TITLE
Minispade code wrapper should deal with last-line being a comment 

### DIFF
--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -50,9 +50,9 @@ module Rake::Pipeline::Web::Filters
         module_id = @module_id_generator.call(input)
 
         if @string_module
-          contents = %{(function() {#{code}})();\n//@ sourceURL=#{module_id}}.to_json
+          contents = %{(function() {#{code}\n})();\n//@ sourceURL=#{module_id}}.to_json
         else
-          contents = "function() {#{code}}"
+          contents = "function() {#{code}\n}"
         end
         ret = "minispade.register('#{module_id}', #{contents});"
         output.write ret

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -3,7 +3,7 @@ require "json"
 describe "MinispadeFilter" do
   MemoryFileWrapper ||= Rake::Pipeline::SpecHelpers::MemoryFileWrapper
 
-  def input_file(contents="var foo = 'bar';", path="/path/to/input", name="foo.js")
+  def input_file(contents="var foo = 'bar'; // last-line comment", path="/path/to/input", name="foo.js")
     MemoryFileWrapper.new(path, name, "UTF-8", contents)
   end
 
@@ -32,36 +32,36 @@ describe "MinispadeFilter" do
     filter.output_files.should == output_files
     output_file.encoding.should == "UTF-8"
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {var foo = 'bar';});"
+      "minispade.register('/path/to/input/foo.js', function() {var foo = 'bar'; // last-line comment\n});"
   end
 
   it "uses strict if asked" do
     filter = make_filter(input_file, :use_strict => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {\"use strict\";\nvar foo = 'bar';});"
+      "minispade.register('/path/to/input/foo.js', function() {\"use strict\";\nvar foo = 'bar'; // last-line comment\n});"
   end
 
   it "compiles a string if asked" do
     filter = make_filter(input_file, :string => true)
     output_file.body.should ==
-      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar';})();\\n//@ sourceURL=/path/to/input/foo.js");}
+      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar'; // last-line comment\\n})();\\n//@ sourceURL=/path/to/input/foo.js");}
   end
 
   it "takes a proc to name the module" do
     filter = make_filter(input_file, :module_id_generator => proc { |input| "octopus" })
     output_file.body.should ==
-      "minispade.register('octopus', function() {var foo = 'bar';});"
+      "minispade.register('octopus', function() {var foo = 'bar'; // last-line comment\n});"
   end
 
   it "rewrites requires if asked" do
     filter = make_filter(input_file("require('octopus');"), :rewrite_requires => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');});"
+      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');\n});"
   end
 
   it "rewrites requires if asked even spaces wrap tokens in the require statement" do
     filter = make_filter(input_file("require    ( 'octopus');"), :rewrite_requires => true)
     output_file.body.should ==
-      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');});"
+      "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');\n});"
   end
 end


### PR DESCRIPTION
If the code to be registered has a comment on the last line, the closing part of the registration wrapper becomes a comment as well, resulting in invalid code.

``` javascript
alert('hello world');
// Hello World
```

results in,

``` javascript
minispade.register('module_id', function() {alert('hello world');
// Hello World});
```

Added a new line to the code during registration to deal with a comment as the last line of the code. Now, the registration looks like this,

``` javascript
minispade.register('module_id', function() {alert('hello world');
// Hello World
});
```
