### PR TITLE
Allow handlebars filter to take an option(proc) that sets the template key name

### DIFF
--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -35,7 +35,7 @@ module Rake::Pipeline::Web::Filters
       @options = {
           :target =>'Ember.TEMPLATES',
           :wrapper_proc => proc { |source| "Ember.Handlebars.compile(#{source});" },
-          :key_name => proc { |input| File.basename(input.path, File.extname(input.path)) }
+          :key_name_proc => proc { |input| File.basename(input.path, File.extname(input.path)) }
         }.merge(options)
     end
 
@@ -43,7 +43,7 @@ module Rake::Pipeline::Web::Filters
 
       inputs.each do |input|
         # The name of the template is the filename, sans extension
-        name = options[:key_name].call(input)
+        name = options[:key_name_proc].call(input)
 
         # Read the file and escape it so it's a valid JS string
         source = input.read.to_json

--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -34,7 +34,8 @@ module Rake::Pipeline::Web::Filters
       super(&block)
       @options = {
           :target =>'Ember.TEMPLATES',
-          :wrapper_proc => proc { |source| "Ember.Handlebars.compile(#{source});" }
+          :wrapper_proc => proc { |source| "Ember.Handlebars.compile(#{source});" },
+          :key_name => proc { |input| File.basename(input.path, File.extname(input.path)) }
         }.merge(options)
     end
 
@@ -42,7 +43,7 @@ module Rake::Pipeline::Web::Filters
 
       inputs.each do |input|
         # The name of the template is the filename, sans extension
-        name = File.basename(input.path, File.extname(input.path))
+        name = options[:key_name].call(input)
 
         # Read the file and escape it so it's a valid JS string
         source = input.read.to_json

--- a/spec/handlebars_filter_spec.rb
+++ b/spec/handlebars_filter_spec.rb
@@ -53,7 +53,7 @@ describe "HandlebarsFilter" do
 
   describe "options" do
     it "should allow an option to name the key" do
-      filter = setup_filter(HandlebarsFilter.new(:key_name => proc { |input| "new_name_key" }))
+      filter = setup_filter(HandlebarsFilter.new(:key_name_proc => proc { |input| "new_name_key" }))
         
       tasks = filter.generate_rake_tasks
       tasks.each(&:invoke)

--- a/spec/handlebars_filter_spec.rb
+++ b/spec/handlebars_filter_spec.rb
@@ -50,4 +50,16 @@ describe "HandlebarsFilter" do
       filter.output_files.first.path.should == "squid"
     end
   end
+
+  describe "options" do
+    it "should allow an option to name the key" do
+      filter = setup_filter(HandlebarsFilter.new(:key_name => proc { |input| "new_name_key" }))
+        
+      tasks = filter.generate_rake_tasks
+      tasks.each(&:invoke)
+
+      file = MemoryFileWrapper.files["/path/to/output/test.js"]
+      file.body.should =~ /^Ember\.TEMPLATES\['new_name_key'\]/
+    end
+  end
 end


### PR DESCRIPTION
Before the Ember.TEMPLATES key was the basename of the file.  This allows the user to pass a proc with options that lets them generate a new key.  The proc takes an input argument.  Let me know if you need more tests (I noticed the options were not tested, so I only added one quick test)
