### PR TITLE
Added files within additional load paths sass filter to output file dependencies

### DIFF
--- a/lib/rake-pipeline-web-filters/sass_filter.rb
+++ b/lib/rake-pipeline-web-filters/sass_filter.rb
@@ -63,13 +63,23 @@ module Rake::Pipeline::Web::Filters
       end.flatten
     end
 
-  private
-
+    # Overwritten method from rake-pipeline
+    #
     # Make sure that files within additional load paths are watched for changes
-    def create_file_task(output, deps=[], &block)
-      deps.concat(additional_file_paths)
-      super(output, deps, &block)
+    # @return [void]
+    def generate_rake_tasks
+      @rake_tasks = outputs.map do |output, inputs|
+        dependencies = inputs.map(&:fullpath) + additional_file_paths
+
+        dependencies.each { |path| create_file_task(path) }
+
+        create_file_task(output.fullpath, dependencies) do
+          output.create { generate_output(inputs, output) }
+        end
+      end
     end
+
+  private
 
     def external_dependencies
       [ 'sass', 'compass' ]


### PR DESCRIPTION
Hi.

I had problem with refreshing generated style file, when my main sass file was importing partials.

Sample directory and Assetfile:

app/stylesheets/application.sass
app/stylesheets/partials/_reset.sass
app/stylesheets/partials/_layout.sass

``` ruby
match "stylesheets/application.sass" do
  sass additional_load_paths: "app/stylesheets/partials/"
  copy "stylesheets/application.css"
end
```

Changes made in files within partials, weren't always refreshed in generated application.css file.

This pull request fixes it by adding files from `additional_load_paths` to output file dependencies
