### PR TITLE
Rename both .hbs and .handlebars files to .js by default.

### DIFF
--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -30,7 +30,7 @@ module Rake::Pipeline::Web::Filters
     #   {#output_name_generator}.
     def initialize(options={},&block)
       # Convert .handlebars file extensions to .js
-      block ||= proc { |input| input.sub(/\.handlebars$/, '.js') }
+      block ||= proc { |input| input.sub(/\.handlebars|\.hbs$/, '.js') }
       super(&block)
       @options = {
           :target =>'Ember.TEMPLATES',


### PR DESCRIPTION
Would be nice if both .hbs and .handlebars extensions were renamed in the handlebars filter. Tried to add a spec too, but I've never used rspec so I couldn't easily add a test. If that's needed perhaps you can add one?
