### PR TITLE
YUI Compress and Ugilifier skip files named .min

### DIFF
--- a/lib/rake-pipeline-web-filters/uglify_filter.rb
+++ b/lib/rake-pipeline-web-filters/uglify_filter.rb
@@ -27,7 +27,14 @@ module Rake::Pipeline::Web::Filters
     # @param [Proc] block a block to use as the Filter's
     #   {#output_name_generator}.
     def initialize(options={}, &block)
-      block ||= proc { |input| input.sub(/\.js$/, '.min.js') }
+      block ||= proc { |input| 
+        if input =~ %r{min.js$}
+          input
+        else
+          input.sub(/\.js$/, '.min.js')
+        end
+      }
+
       super(&block)
       @options = options
     end
@@ -42,7 +49,11 @@ module Rake::Pipeline::Web::Filters
     #   object representing the output.
     def generate_output(inputs, output)
       inputs.each do |input|
-        output.write Uglifier.compile(input.read, options)
+        if input.path =~ %r{min.js$}
+          output.write input.read
+        else
+          output.write Uglifier.compile(input.read, options)
+        end
       end
     end
 

--- a/lib/rake-pipeline-web-filters/yui_css_filter.rb
+++ b/lib/rake-pipeline-web-filters/yui_css_filter.rb
@@ -28,7 +28,14 @@ module Rake::Pipeline::Web::Filters
     # @param [Proc] block a block to use as the Filter's
     #   {#output_name_generator}.
     def initialize(options={}, &block)
-      block ||= proc { |input| input.sub(/\.css$/, '.min.css') }
+      block ||= proc { |input| 
+        if input =~ %r{min.css$}
+          input
+        else
+          input.sub /\.css$/, '.min.css'
+        end
+      }
+
       super(&block)
       @options = options
     end
@@ -45,7 +52,11 @@ module Rake::Pipeline::Web::Filters
     def generate_output(inputs, output)
       compressor = YUI::CssCompressor.new(options)
       inputs.each do |input|
-        output.write compressor.compress(input.read)
+        if input.path !~ /min\.css/
+          output.write compressor.compress(input.read)
+        else
+          output.write input.read
+        end
       end
     end
 

--- a/spec/uglify_filter_spec.rb
+++ b/spec/uglify_filter_spec.rb
@@ -44,6 +44,20 @@ HERE
     file.encoding.should == "UTF-8"
   end
 
+  it "skips minified files" do
+    filter = setup_filter UglifyFilter.new
+    filter.input_files = [input_file("name.min.js", 'fake-js')]
+
+    filter.output_files.should == [output_file("name.min.js")]
+
+    tasks = filter.generate_rake_tasks
+    tasks.each(&:invoke)
+
+    file = MemoryFileWrapper.files["/path/to/output/name.min.js"]
+    file.body.should == 'fake-js'
+    file.encoding.should == "UTF-8"
+  end
+
   describe "naming output files" do
     it "translates .js extensions to .min.js by default" do
       filter = setup_filter UglifyFilter.new

--- a/spec/yui_css_filter_spec.rb
+++ b/spec/yui_css_filter_spec.rb
@@ -48,6 +48,21 @@ HERE
     file.encoding.should == "UTF-8"
   end
 
+  it "skips files named .min" do
+    filter = setup_filter YUICssFilter.new
+
+    filter.input_files = [input_file("error.min.css", "fake-css")]
+
+    filter.output_files.should == [output_file("error.min.css")]
+
+    tasks = filter.generate_rake_tasks
+    tasks.each(&:invoke)
+
+    file = MemoryFileWrapper.files["/path/to/output/error.min.css"]
+    file.body.should == "fake-css"
+    file.encoding.should == "UTF-8"
+  end
+
   describe "naming output files" do
     it "translates .css extensions to .min.css by default" do
       filter = setup_filter YUICssFilter.new


### PR DESCRIPTION
Title says it all. Now you can just throw all your JS files into the pipeline and not spend a ton of time compressing jquery.min.js or boostrap.min.css.
