### PR TITLE
Add requireAll support to minispade filter

### DIFF
--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -45,6 +45,7 @@ module Rake::Pipeline::Web::Filters
       inputs.each do |input|
         code = input.read
         code.gsub!(%r{^\s*require\s*\(\s*}, 'minispade.require(') if @rewrite_requires
+        code.gsub!(%r{^\s*requireAll\s*\(\s*}, 'minispade.requireAll(') if @rewrite_requires
         code = %["use strict";\n] + code if @use_strict
 
         module_id = @module_id_generator.call(input)

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -64,4 +64,16 @@ describe "MinispadeFilter" do
     output_file.body.should ==
       "minispade.register('/path/to/input/foo.js', function() {minispade.require('octopus');\n});"
   end
+  
+  it "rewrites requireAll if asked" do
+    filter = make_filter(input_file("requireAll('octopus');"), :rewrite_requires => true)
+    output_file.body.should ==
+      "minispade.register('/path/to/input/foo.js', function() {minispade.requireAll('octopus');\n});"
+  end
+
+  it "rewrites requireAll if asked even spaces wrap tokens in the require statement" do
+    filter = make_filter(input_file("requireAll    ( 'octopus');"), :rewrite_requires => true)
+    output_file.body.should ==
+      "minispade.register('/path/to/input/foo.js', function() {minispade.requireAll('octopus');\n});"
+  end
 end


### PR DESCRIPTION
I noticed wycats had added requireAll to minispade, this just adds that functionality to the rake-pipeline-web-filters.
