### PR TITLE
Default values are not allowed before required values in Ruby 1.8

### DIFF
--- a/lib/rake-pipeline-web-filters/neuter_filter.rb
+++ b/lib/rake-pipeline-web-filters/neuter_filter.rb
@@ -1,8 +1,8 @@
 module Rake::Pipeline::Web::Filters
 
   class NeuterBatch
-    def initialize(config={}, known_files)
-      @config = config
+    def initialize(config, known_files)
+      @config = config || {}
       @known_files = known_files
       @required = []
     end


### PR DESCRIPTION
Fixes neuter filter from blowing up on Ruby 1.8. Let me know if Rake-Pipeline isn't supported on 1.8
