### PR TITLE
Add :compiler_proc option to HandlebarsFilter

### DIFF
--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -20,12 +20,14 @@ module Rake::Pipeline::Web::Filters
 
     # @param [Hash] options
     #   options to pass to the output generator
-    # @option options [Array] :target
+    # @option options [String] :target
     #   the variable to store templates in
-    # @option options [Array] :compile_open
+    # @option options [Proc] :wrapper_proc
     #   the js to wrap template contents in
-    # @option options [Array] :compile_close
-    #   the js to wrap template contents in
+    # @option options [Proc] :compiler_proc
+    #   processes the source. Return value is passed to wrapper_proc
+    # @option options [Proc] :key_name_proc
+    #   used to determine the template name
     # @param [Proc] block a block to use as the Filter's
     #   {#output_name_generator}.
     def initialize(options={},&block)
@@ -36,7 +38,7 @@ module Rake::Pipeline::Web::Filters
           :target =>'Ember.TEMPLATES',
           :wrapper_proc => proc { |source| "Ember.Handlebars.compile(#{source});" },
           :key_name_proc => proc { |input| File.basename(input.path, File.extname(input.path)) },
-          :compiler => proc { |source| source },
+          :compiler_proc => proc { |source| source },
         }.merge(options)
     end
 
@@ -47,7 +49,7 @@ module Rake::Pipeline::Web::Filters
         name = options[:key_name_proc].call(input)
 
         # Read the file and escape it so it's a valid JS string
-        source = options[:compiler].call(input.read.to_json)
+        source = options[:compiler_proc].call(input.read.to_json)
 
         # Write out a JS file, saved to target, wrapped in compiler
         output.write "#{options[:target]}['#{name}']=#{options[:wrapper_proc].call(source)}"

--- a/lib/rake-pipeline-web-filters/handlebars_filter.rb
+++ b/lib/rake-pipeline-web-filters/handlebars_filter.rb
@@ -35,7 +35,8 @@ module Rake::Pipeline::Web::Filters
       @options = {
           :target =>'Ember.TEMPLATES',
           :wrapper_proc => proc { |source| "Ember.Handlebars.compile(#{source});" },
-          :key_name_proc => proc { |input| File.basename(input.path, File.extname(input.path)) }
+          :key_name_proc => proc { |input| File.basename(input.path, File.extname(input.path)) },
+          :compiler => proc { |source| source },
         }.merge(options)
     end
 
@@ -46,7 +47,7 @@ module Rake::Pipeline::Web::Filters
         name = options[:key_name_proc].call(input)
 
         # Read the file and escape it so it's a valid JS string
-        source = input.read.to_json
+        source = options[:compiler].call(input.read.to_json)
 
         # Write out a JS file, saved to target, wrapped in compiler
         output.write "#{options[:target]}['#{name}']=#{options[:wrapper_proc].call(source)}"

--- a/spec/handlebars_filter_spec.rb
+++ b/spec/handlebars_filter_spec.rb
@@ -59,12 +59,22 @@ describe "HandlebarsFilter" do
   describe "options" do
     it "should allow an option to name the key" do
       filter = setup_filter(HandlebarsFilter.new(:key_name_proc => proc { |input| "new_name_key" }))
-        
+
       tasks = filter.generate_rake_tasks
       tasks.each(&:invoke)
 
       file = MemoryFileWrapper.files["/path/to/output/test.js"]
       file.body.should =~ /^Ember\.TEMPLATES\['new_name_key'\]/
+    end
+
+    it "should have a compiler options" do
+      filter = setup_filter(HandlebarsFilter.new(:compiler => proc { |source| "COMPILED(#{source})" }))
+
+      tasks = filter.generate_rake_tasks
+      tasks.each(&:invoke)
+
+      file = MemoryFileWrapper.files["/path/to/output/test.js"]
+      file.body.should =~ /COMPILED\(.+\)/
     end
   end
 end

--- a/spec/handlebars_filter_spec.rb
+++ b/spec/handlebars_filter_spec.rb
@@ -67,8 +67,8 @@ describe "HandlebarsFilter" do
       file.body.should =~ /^Ember\.TEMPLATES\['new_name_key'\]/
     end
 
-    it "should have a compiler options" do
-      filter = setup_filter(HandlebarsFilter.new(:compiler => proc { |source| "COMPILED(#{source})" }))
+    it "should have a compiler_proc options" do
+      filter = setup_filter(HandlebarsFilter.new(:compiler_proc => proc { |source| "COMPILED(#{source})" }))
 
       tasks = filter.generate_rake_tasks
       tasks.each(&:invoke)


### PR DESCRIPTION
`compiler_proc` is called with the source. The `compiler_proc` returns the source by default. You can specify `compiler_proc` if you want to preprocess the source before it hits `wrapper_proc`. `compiler_proc` and `wrapper_proc` can be set in coordination to do Handlebars precompilation. Here's an example.

``` ruby
# how to precompile handlebars templates
handlebars :wrapper_proc => proc { |source| "Ember.Handlebars.template(#{source});" },
  :compiler_proc => proc { |template| MyCompiler.compile(template) }
```

I've also updated the docs in this PR.
