### PR TITLE
Only skip files with the ".min.js" postfix

### DIFF
--- a/lib/rake-pipeline-web-filters/uglify_filter.rb
+++ b/lib/rake-pipeline-web-filters/uglify_filter.rb
@@ -28,7 +28,7 @@ module Rake::Pipeline::Web::Filters
     #   {#output_name_generator}.
     def initialize(options={}, &block)
       block ||= proc { |input| 
-        if input =~ %r{min.js$}
+        if input =~ %r{.min.js$}
           input
         else
           input.sub(/\.js$/, '.min.js')
@@ -49,7 +49,7 @@ module Rake::Pipeline::Web::Filters
     #   object representing the output.
     def generate_output(inputs, output)
       inputs.each do |input|
-        if input.path =~ %r{min.js$}
+        if input.path =~ %r{.min.js$}
           output.write input.read
         else
           output.write Uglifier.compile(input.read, options)

--- a/spec/uglify_filter_spec.rb
+++ b/spec/uglify_filter_spec.rb
@@ -47,18 +47,34 @@ HERE
     file.encoding.should == "UTF-8"
   end
 
-  it "skips minified files" do
-    filter = setup_filter UglifyFilter.new
-    filter.input_files = [input_file("name.min.js", 'fake-js')]
+  describe "Skipping" do
+    it "skips files ending in .min.js" do
+      filter = setup_filter UglifyFilter.new
+      filter.input_files = [input_file("name.min.js", 'fake-js')]
 
-    filter.output_files.should == [output_file("name.min.js")]
+      filter.output_files.should == [output_file("name.min.js")]
 
-    tasks = filter.generate_rake_tasks
-    tasks.each(&:invoke)
+      tasks = filter.generate_rake_tasks
+      tasks.each(&:invoke)
 
-    file = MemoryFileWrapper.files["/path/to/output/name.min.js"]
-    file.body.should == 'fake-js'
-    file.encoding.should == "UTF-8"
+      file = MemoryFileWrapper.files["/path/to/output/name.min.js"]
+      file.body.should == 'fake-js'
+      file.encoding.should == "UTF-8"
+    end
+
+    it "does not count files ending in min.js as preminified" do
+      filter = setup_filter UglifyFilter.new
+      filter.input_files = [input_file("min.js", js_input)]
+
+      filter.output_files.should == [output_file("min.min.js")]
+
+      tasks = filter.generate_rake_tasks
+      tasks.each(&:invoke)
+
+      file = MemoryFileWrapper.files["/path/to/output/min.min.js"]
+      file.body.should == expected_js_output
+      file.encoding.should == "UTF-8"
+    end
   end
 
   describe "naming output files" do


### PR DESCRIPTION
Previously files with "min.js" would be skipped. This would skip files
named "min.js" or simply ending in "min.js"
