### PR TITLE
typo in README about coffee_script helper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ output "site"
 
 input "javascripts" do
   match "**/*.coffee" do
-    coffeescript
+    coffee_script
   end
 
   match "**/*.js" do


### PR DESCRIPTION
typo in README : the helper is coffee_script not coffeescript
