### PR TITLE
Allow passing options to the ChainedFilter via an Array

### DIFF
--- a/lib/rake-pipeline-web-filters/chained_filter.rb
+++ b/lib/rake-pipeline-web-filters/chained_filter.rb
@@ -105,12 +105,24 @@ module Rake::Pipeline::Web::Filters
     #
     # Process an individual file with a filter.
     def process_with_filter(input, filter_class)
-      filter = filter_class.new
+      filter = instantiate_filter(filter_class)
 
       output = MemoryFileWrapper.new("/output", input.path, "UTF-8")
       output.create { filter.generate_output([input], output) }
 
       output
+    end
+
+    # @private
+    #
+    # Instantiates a filter from a Class or an Array like [MyClass, option1, option2...]
+    def instantiate_filter(arg)
+      if arg.respond_to?(:new)
+        arg.new
+      else
+        filter_class = arg.first
+        filter_class.new(*arg[(1..-1)])
+      end
     end
   end
 end

--- a/spec/chained_filter_spec.rb
+++ b/spec/chained_filter_spec.rb
@@ -15,6 +15,12 @@ Input = {};
 <%= $chained_filter_title %> = {};
   CONTENT
 
+  input_file_accessing_context = MemoryFileWrapper.new("/path", "input.js.erb.strip_asserts", "UTF-8", <<-CONTENT)
+assert("must be true", true);
+Input = {};
+<%= coming_from_context %> = {};
+  CONTENT
+
   EXPECTED_OUTPUT = <<-EXPECTED
 
 Input = {};
@@ -23,9 +29,13 @@ Chained = {};
 
   let(:erb_filter) do
     Class.new(Rake::Pipeline::Filter) do
+      def initialize(context=nil)
+        @context = context
+      end
+
       def generate_output(inputs, output)
         inputs.each do |input|
-          output.write ERB.new(input.read).result
+          output.write ERB.new(input.read).result(@context)
         end
       end
     end
@@ -49,21 +59,25 @@ Chained = {};
     $chained_filter_title = nil
   end
 
+  def setup_filter(filter)
+    filter.file_wrapper_class = MemoryFileWrapper
+    filter.manifest = MemoryManifest.new
+    filter.last_manifest = MemoryManifest.new
+    filter.output_root = "/output"
+    filter.rake_application = Rake::Application.new
+    filter
+  end
+
   [ input_file1, input_file2 ].each do |file_wrapper|
     it "should run through the filters in order" do
-      filter = ChainedFilter.new(
+      filter = setup_filter ChainedFilter.new(
         :types => {
           :erb => erb_filter,
           :strip_asserts => strip_asserts_filter
         }
       )
 
-      filter.file_wrapper_class = MemoryFileWrapper
-      filter.manifest = MemoryManifest.new
-      filter.last_manifest = MemoryManifest.new
       filter.input_files = [ file_wrapper ]
-      filter.output_root = "/output"
-      filter.rake_application = Rake::Application.new
 
       filter.output_files.should == [ MemoryFileWrapper.new("/output", "input.js", "UTF-8") ]
 
@@ -74,6 +88,25 @@ Chained = {};
       file.body.should == EXPECTED_OUTPUT
       file.encoding.should == "UTF-8"
     end
+  end
+
+  it 'allows passing options to a filter' do
+      coming_from_context = 'Chained'
+
+      filter = setup_filter ChainedFilter.new(
+        :types => {
+          :erb => [ erb_filter, binding ],
+          :strip_asserts => strip_asserts_filter
+        }
+      )
+
+      filter.input_files = [ input_file_accessing_context ]
+
+      tasks = filter.generate_rake_tasks
+      tasks.each(&:invoke)
+
+      file = MemoryFileWrapper.files["/output/input.js"]
+      file.body.should == EXPECTED_OUTPUT
   end
 
 end


### PR DESCRIPTION
The ChainedFilter is really handy. I wanted to adjust the used filters a little, so this patch allows to pass options via an Array like:

``` ruby
filter Web::Filters::ChainedFilter, {
  types: {
    erb: [Web::Filters::TiltFilter, {}, my_context],
    haml: [Web::Filters::TiltFilter, {}, my_context],
    coffee: CoffeeScriptFilter
  }
}
```

I chose an Array to pass the options, because it's easy and resembles the filter syntax `filter MyClass, option1, option2`.

I am not using `#register` right now. You could also pass an Array to that method, but maybe we should change the register method to allow something like `register :type, MyFilter, option1, option2`, ping me if you think that's a good idea.
