### PR TITLE
Update sourceURL syntax to latest standard.

### DIFF
--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -51,7 +51,7 @@ module Rake::Pipeline::Web::Filters
         module_id = @module_id_generator.call(input)
 
         if @string_module
-          contents = %{(function() {#{code}\n})();\n/*@if (@_jscript) @else @*/\n//@ sourceURL=#{module_id}\n/*@end@*/}.to_json
+          contents = %{(function() {#{code}\n})();\n/*@if (@_jscript) @else @*/\n//# sourceURL=#{module_id}\n/*@end@*/}.to_json
         else
           contents = "function() {#{code}\n}"
         end

--- a/lib/rake-pipeline-web-filters/minispade_filter.rb
+++ b/lib/rake-pipeline-web-filters/minispade_filter.rb
@@ -51,7 +51,7 @@ module Rake::Pipeline::Web::Filters
         module_id = @module_id_generator.call(input)
 
         if @string_module
-          contents = %{(function() {#{code}\n})();\n/*@if (@_jscript) @else @*/\n//# sourceURL=#{module_id}\n/*@end@*/}.to_json
+          contents = %{(function() {#{code}\n})();\n//# sourceURL=#{module_id}}.to_json
         else
           contents = "function() {#{code}\n}"
         end

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -47,7 +47,7 @@ describe "MinispadeFilter" do
   it "compiles a string if asked" do
     filter = make_filter(input_file, :string => true)
     output_file.body.should ==
-      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar'; // last-line comment\\n})();\\n/*@if (@_jscript) @else @*/\\n//@ sourceURL=/path/to/input/foo.js\\n/*@end@*/");}
+      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar'; // last-line comment\\n})();\\n/*@if (@_jscript) @else @*/\\n//# sourceURL=/path/to/input/foo.js\\n/*@end@*/");}
   end
 
   it "takes a proc to name the module" do

--- a/spec/minispade_filter_spec.rb
+++ b/spec/minispade_filter_spec.rb
@@ -47,7 +47,7 @@ describe "MinispadeFilter" do
   it "compiles a string if asked" do
     filter = make_filter(input_file, :string => true)
     output_file.body.should ==
-      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar'; // last-line comment\\n})();\\n/*@if (@_jscript) @else @*/\\n//# sourceURL=/path/to/input/foo.js\\n/*@end@*/");}
+      %{minispade.register('/path/to/input/foo.js', "(function() {var foo = 'bar'; // last-line comment\\n})();\\n//# sourceURL=/path/to/input/foo.js");}
   end
 
   it "takes a proc to name the module" do


### PR DESCRIPTION
Recent Chrome dev channel builds have deprecated `//@ sourceUrl=` in
favor of `//# sourceUrl=`.
