### PR TITLE
Fixing failed tests

### DIFF
--- a/lib/rake-pipeline-web-filters/uglify_filter.rb
+++ b/lib/rake-pipeline-web-filters/uglify_filter.rb
@@ -59,7 +59,7 @@ module Rake::Pipeline::Web::Filters
         if should_skip_minify?(input, output)
           output.write input.read
         else
-          output.write Uglifier.compile(input.read, options)
+          output.write Uglifier.compile(input.read, output: options)
         end
       end
     end

--- a/spec/coffee_script_filter_spec.rb
+++ b/spec/coffee_script_filter_spec.rb
@@ -105,7 +105,7 @@ y = function(){
       tasks = filter.generate_rake_tasks
       lambda {
         tasks.each(&:invoke)
-      }.should raise_error(ExecJS::RuntimeError, /Error compiling input.coffee.+line 1/i)
+      }.should raise_error(ExecJS::RuntimeError, /Error compiling input.coffee.+/i)
     end
   end
 

--- a/spec/jade_filter_spec.rb
+++ b/spec/jade_filter_spec.rb
@@ -4,7 +4,7 @@ describe "JadeFilter" do
 
   let(:jade_input) {
     """
-!!! 5
+doctype html
 html
   head
     title Hello

--- a/spec/uglify_filter_spec.rb
+++ b/spec/uglify_filter_spec.rb
@@ -13,7 +13,7 @@ HERE
   }
 
   let(:expected_beautiful_js_output) {
-    %[var name = "Truckasaurus Gates";\n\nconsole.log(name);;]
+    %[var name = "Truckasaurus Gates";\n\nconsole.log(name);]
   }
 
   let(:filter_args) { [] }


### PR DESCRIPTION
Fixes Uglify, CoffeeScript and Jade tests that have been failing for a while now:

Uglify -- needs an extra "output: " for passing in beautify: true parameter

CoffeeScript -- has a different error message (does not mention line number, but provides backtrace instead).  also, removing an extra semicolon

Jade -- !!! is deprecated
