### PR TITLE
allowing more uglifier options other than :output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
--cfs -r spec_helper.rb
+-c -f d -r spec_helper.rb

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "bundler/setup"
 
 desc "run the specs"
 task :spec do
-  sh "rspec -cfs spec"
+  sh "rspec -c -f d spec"
 end
 
 task :default => :spec

--- a/lib/rake-pipeline-web-filters/uglify_filter.rb
+++ b/lib/rake-pipeline-web-filters/uglify_filter.rb
@@ -59,7 +59,7 @@ module Rake::Pipeline::Web::Filters
         if should_skip_minify?(input, output)
           output.write input.read
         else
-          output.write Uglifier.compile(input.read, output: options)
+          output.write Uglifier.compile(input.read, options)
         end
       end
     end

--- a/spec/uglify_filter_spec.rb
+++ b/spec/uglify_filter_spec.rb
@@ -114,7 +114,7 @@ HERE
 
   context "with Uglify options" do
     let(:filter_args) do
-      [{ :beautify => true }]
+      [output: { :beautify => true }]
     end
 
     it "passes options to the Uglify compressor" do


### PR DESCRIPTION
fixes an uglifier issue mentioned in PR here: https://github.com/wycats/rake-pipeline-web-filters/pull/70

also fixed a rspec configuration error that were breaking tests for rspec 3.0.0
